### PR TITLE
[KEYCLOAK-10801] Provide recommendation about how to properly handle filtering

### DIFF
--- a/design/rest-api-guideline.md
+++ b/design/rest-api-guideline.md
@@ -458,25 +458,13 @@ Sometimes, we need more control over the content that will return from the serve
 
 The Keycloak admin REST API allows to search for users based on `e-mail`, `first name`, `lastname` and other optional parameters. However, such implementation is limited to a particular context (e.g, collection of users).
 
-Filtering can be implemented as a query parameter, like we already did for the current REST API, with some enhancements. To filter on a field, should be as simple as the following request:
+Filtering should be implemented as a query parameter, based on what we already do today. To filter on a field, should be as simple as the following request:
 
 ```
-/{realm}/apis/admin/users/v1?group=users1&realm=master&sort=desc
+/{realm}/apis/admin/users/v1?group=users1
 ```
 
-Multiple filters should result in an implicit `AND`, so in our example `/v1?group=users1&role=role1&realm=master&sort=desc` would provide results based on `groups`, `roles` and `realm`. Now let's say we want filter based on more than one groups:
-
-```
-/{realm}/apis/admin/users/v1?group=in:users1,users2&realm=master&sort=desc
-```
-
-A brief explanation about the parameters:
-
-|Name|Type|Description|
-|---|---|---|
-|sort|string|Sort the results on our query based on: date, ascending order and descending order|
-|in|string|Query for values inside a collection. For example: users belonging to group1 `and` group2.
-|or|string|Query for values inside a collection. For example: users belonging to group1 `or` group2.
+Multiple filters should result in an implicit `AND`, so in our example `/v1?group=users1&role=role1` would provide results based on `groups` and `roles`. Filtering should take into consideration the list of attributes supported by the API.
 
 ### Concurrency Control and Consistency
 

--- a/design/rest-api-guideline.md
+++ b/design/rest-api-guideline.md
@@ -454,7 +454,29 @@ Keycloak does not provide rate limiting capabilities and for such it is necessar
 
 ### Filtering
 
-TODO
+Sometimes, we need more control over the content that will return from the server, so that only a subset of the data is available in the response. For example, a list user's groups or permissions. 
+
+The Keycloak admin REST API allows to search for users based on `e-mail`, `first name`, `lastname` and other optional parameters. However, such implementation is limited to a particular context (e.g, collection of users).
+
+Filtering can be implemented as a query parameter, like we already did for the current REST API, with some enhancements. To filter on a field, should be as simple as the following request:
+
+```
+/{realm}/apis/admin/users/v1?group=users1&realm=master&sort=desc
+```
+
+Multiple filters should result in an implicit `AND`, so in our example `/v1?group=users1&role=role1&realm=master&sort=desc` would provide results based on `groups`, `roles` and `realm`. Now let's say we want filter based on more than one groups:
+
+```
+/{realm}/apis/admin/users/v1?group=in:users1,users2&realm=master&sort=desc
+```
+
+A brief explanation about the parameters:
+
+|Name|Type|Description|
+|---|---|---|
+|sort|string|Sort the results on our query based on: date, ascending order and descending order|
+|in|string|Query for values inside a collection. For example: users belonging to group1 `and` group2.
+|or|string|Query for values inside a collection. For example: users belonging to group1 `or` group2.
 
 ### Concurrency Control and Consistency
 


### PR DESCRIPTION
### Minor consideration
It is possible to provide more generic queries like GitHub does in the future, by using something like /commits?q=repo:octocat. But for now, I'd vote to not over complicate things and stick with simple. At the moment we don't have anything that justifies generic queries in the Account REST API