### PR TITLE
KEYCLOAK-17399 - JSON configuration format refined for implementation

### DIFF
--- a/design/user-profile.md
+++ b/design/user-profile.md
@@ -124,7 +124,8 @@ Some configuration sections use these pseudo-roles:
 * `admin` - activities from User management part of the Admin REST API (covers Admin console). It is expected that this part will be evolved in the future to use Roles defined for realm in the admin console to allow fine grained control for attributes access.
 
 
-JSON configuration contains `attributes` field which defines user profile attributes available in the realm. It is an array of attribute definition objects configuring individual attributes.
+JSON configuration contains `attributes` field which defines user profile attributes available in the realm. It is an array of attribute definition objects configuring individual attributes. 
+Order of attributes in this array is reflected when dynamic user profile forms are rendered in GUI.
 
 Attribute definition object contains `name` field with name of the attribute being configured by it. `name` it is required, must be unique in the array. Can contain only lowercase and uppercase letters, numbers and special characters `.`, `-` and `_`.
 

--- a/design/user-profile.md
+++ b/design/user-profile.md
@@ -89,11 +89,14 @@ Format of the User profile JSON configuration settled during implementation in M
             "permissions": {
                 "view": ["admin", "user"], 
                 "edit": ["admin"],
-            }
+            },
             "required": {
                 "roles" : ["user", "admin"],
                 "scopes" : ["phone-1", "phone-2"]
-            }
+            },
+            "selector": {
+                "scopes" : ["phone-1", "phone-2", "phone-optional"]
+            },
             "validations": {
                 "length" : { "min" : 10, "max": 20 },
                 "startsUppercase" : {}
@@ -123,7 +126,7 @@ Some configuration sections use these pseudo-roles:
 
 JSON configuration contains `attributes` field which defines user profile attributes available in the realm. It is an array of attribute definition objects configuring individual attributes.
 
-Attribute definition object contains `name` field with name of the attribute being configured by it. `name` it is required, must be unique in the array. Can contain only lowercase and uppercase letters, numbers and special characters `.`, `-` and `_`
+Attribute definition object contains `name` field with name of the attribute being configured by it. `name` it is required, must be unique in the array. Can contain only lowercase and uppercase letters, numbers and special characters `.`, `-` and `_`.
 
 Attribute definition object contains other sections described later.
 
@@ -134,6 +137,17 @@ Optional `permissions` structure is used to define permissions for the attribute
 * `view` - array of strings containing pseudo-roles who can view attribute value, nobody can view it if no any role is named here. `username` and `email` fields are always visible to the user even if not configured here. `username` is always visible to admin even if not configured here.
 * `edit` - array of strings containing pseudo-roles who can edit attribute value, nobody can edit it if no any role is named here. `username` and `email` fields may or may not be editable based on other realm settings, configuration here is not important for them if realm business rules do not allow them to be edited.
 
+### Selector
+
+Optional `selector` structure allows additional control about when is attribute selected for processing. It sits on top of the permissions setting (so if permissions denies access to the attribute this selector section has no effect, attribute is not used). Attribute is always selected if this section is missing or empty. If attribute is not selected it means that:
+* it is not validated (even required validation is not performed) when user profile is verified
+* it doesn't appear in registration/user update forms
+* it's value can't be changed
+
+Specific rules can be defined using options:
+* `scopes` - optional array of strings containing names of auth flow scopes for which is attribute selected. Default client scopes are taken into account also, so attribute selection can be defined per client. This section is used only during the auth flow and practically allows to control whether is field for given attribute rendered in the registration or user update form even as optional/not required. 
+
+Note: selector has no effect for `username` and `email` fields.
 
 ### Required attributes
 

--- a/design/user-profile.md
+++ b/design/user-profile.md
@@ -86,6 +86,7 @@ Format of the User profile JSON configuration settled during implementation in M
     {
         "attributes": [{
             "name": "department",
+            "displayName" : "${user_profile.department}",
             "permissions": {
                 "view": ["admin", "user"], 
                 "edit": ["admin"],
@@ -112,7 +113,6 @@ Format of the User profile JSON configuration settled during implementation in M
             "annotations":  {
                 "key": "value",  
                 "framecolor": "red",
-                "gui-order": "1",
                 "type": "dropdown",
                 "defaults" : [1,2,3,5]
             }
@@ -127,6 +127,8 @@ Some configuration sections use these pseudo-roles:
 JSON configuration contains `attributes` field which defines user profile attributes available in the realm. It is an array of attribute definition objects configuring individual attributes.
 
 Attribute definition object contains `name` field with name of the attribute being configured by it. `name` it is required, must be unique in the array. Can contain only lowercase and uppercase letters, numbers and special characters `.`, `-` and `_`.
+
+Attribute definition object contains optional field `displayName` which defines user friendly display name for the attribute used in UI. Name can be entered directly, but field supports keys for localized values as well (for example `${user_profile.department}`). If not defined then `name` itself is used in UI.
 
 Attribute definition object contains other sections described later.
 


### PR DESCRIPTION
JSON configuration format refined for implementation based on meetings and keycloak-dev mailing list discussion:
* `requirement` section polished to `required` and made valid JSON easily parsable from Java code. Functionality is better defined.
* `validation` section - changed to allow more `validations`, context removed (not necessary, format validations should be always same for the attribute), config section polished to be valid parsable JSON.  Functionality is better defined.
* `converter` section - kept in design but not implemented now, can be implemented later once it will be fully clear where and how to use it (design needs to be improved then)
* better defined what does `admin` and `user` pseudo-role mean (used in `permissions` and `required` sections)

Other improvements added later during implementation phase
* attribute selector based on auth flow scopes (allows to show fields in forms as optional)
* user friendly display name for attribute