### PR TITLE
OAuth DAG how-to-try-it initial curl request fix

### DIFF
--- a/design/oauth2-device-authorization-grant.md
+++ b/design/oauth2-device-authorization-grant.md
@@ -99,7 +99,7 @@ Send POST request to the `Device Authorization Endpoint` like below.
 ```
 curl -X POST \
     -d "client_id=foo" \
-    "http://localhost:8080/realms/test/protocol/openid-connect/device/auth"
+    "http://localhost:8080/auth/realms/test/protocol/openid-connect/auth/device"
 ```
 
 It returns a response like below.


### PR DESCRIPTION
The URL used in the initial curl request in the "How to try it" section
showed an incorrect URL:

/realms/test/protocol/openid-connect/device/auth

The current currect URL should be:

/auth/realms/test/protocol/openid-connect/auth/device