### PR TITLE
docs: correct url path to /auth/device

### DIFF
--- a/design/oauth2-device-authorization-grant.md
+++ b/design/oauth2-device-authorization-grant.md
@@ -99,7 +99,7 @@ Send POST request to the `Device Authorization Endpoint` like below.
 ```
 curl -X POST \
     -d "client_id=foo" \
-    "http://localhost:8080/realms/test/protocol/openid-connect/device/auth"
+    "http://localhost:8080/realms/test/protocol/openid-connect/auth/device"
 ```
 
 It returns a response like below.


### PR DESCRIPTION
/device/auth is wrong which cause the error for example: 

```
{
    "error": "RESTEASY003210: Could not find resource for full path: https://keycloak.jiwai.win/auth/realms/UniHeart/protocol/openid-connect/device/auth"
}
```