### PR TITLE
Patch wrong endpoint url in oauth2-device-authorization-grant.md

### DIFF
--- a/design/oauth2-device-authorization-grant.md
+++ b/design/oauth2-device-authorization-grant.md
@@ -99,7 +99,7 @@ Send POST request to the `Device Authorization Endpoint` like below.
 ```
 curl -X POST \
     -d "client_id=foo" \
-    "http://localhost:8080/realms/test/protocol/openid-connect/device/auth"
+    "http://localhost:8080/realms/test/protocol/openid-connect/auth/device"
 ```
 
 It returns a response like below.


### PR DESCRIPTION
patch wrong endpoint url
device/auth should be auth/device